### PR TITLE
ESLint 설정 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,15 +5,11 @@
   },
   "extends": [
     "react-app",
-
     "airbnb",
     "airbnb/hooks",
-
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-
     "plugin:react/recommended",
-
     "plugin:prettier/recommended"
   ],
   "parser": "@typescript-eslint/parser",
@@ -24,7 +20,7 @@
     "ecmaVersion": 13,
     "sourceType": "module"
   },
-  "plugins": ["react", "@typescript-eslint"],
+  "plugins": ["react", "@typescript-eslint", "prettier"],
   "settings": {
     "import/resolver": {
       "node": {
@@ -37,12 +33,12 @@
     "no-param-reassign": ["error", { "props": false }],
     "prefer-destructuring": ["error", { "object": true, "array": false }],
     "no-shadow": "off",
-
+    "@typescript-eslint/no-shadow": ["error"],
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
     "prettier/prettier": [
       "error",
       { "singleQuote": true, "endOfLine": "auto" }
     ],
-
     "import/extensions": [
       "error",
       "ignorePackages",
@@ -55,15 +51,21 @@
         "devDependencies": true
       }
     ],
-
     "react/jsx-filename-extension": [
       1,
       { "extensions": [".js", ".jsx", ".ts", ".tsx"] }
     ],
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",
-
     "jsx-a11y/click-events-have-key-events": "off",
+    "jsx-a11y/label-has-associated-control": [
+      "error",
+      {
+        "labelComponents": ["label"],
+        "labelAttributes": ["htmlFor"],
+        "controlComponents": ["input"]
+      }
+    ],
     "react/require-default-props": "off"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,6 +44,7 @@
       "ignorePackages",
       { "ts": "never", "tsx": "never" }
     ],
+    "no-use-before-define": "off",
     "import/prefer-default-export": "off",
     "import/no-extraneous-dependencies": [
       "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,7 +20,7 @@
     "ecmaVersion": 13,
     "sourceType": "module"
   },
-  "plugins": ["react", "@typescript-eslint", "prettier"],
+  "plugins": ["react", "@typescript-eslint"],
   "settings": {
     "import/resolver": {
       "node": {
@@ -59,14 +59,6 @@
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",
     "jsx-a11y/click-events-have-key-events": "off",
-    "jsx-a11y/label-has-associated-control": [
-      "error",
-      {
-        "labelComponents": ["label"],
-        "labelAttributes": ["htmlFor"],
-        "controlComponents": ["input"]
-      }
-    ],
     "react/require-default-props": "off"
   }
 }


### PR DESCRIPTION
아래와 같은 설정을 제안합니다.
* `plugins`에 prettier 추가
*  `"@typescript-eslint/no-shadow": ["error"]`: outer scope의 변수 이름을 그대로 사용하지 못하도록 제한하는 것이 좋을듯 합니다.
*  `"@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]`: 미사용 변수 정리하는 데 도움을 줍니다.
* `"jsx-a11y/label-has-associated-control": [
      "error",
      {
        "labelComponents": ["label"],
        "labelAttributes": ["htmlFor"],
        "controlComponents": ["input"]
      }
    ]`
*  `"no-use-before-define": "off"`: 메인 함수를 위에 적고 prop 정의 등은 아래에 적는 것이 가독성에 도움이 되는 것 같습니다.
