### PR TITLE
데이터 1개일 때 총점 차트 수정

### DIFF
--- a/src/components/ScoreAnalysis/_components/ScoreTrend.tsx
+++ b/src/components/ScoreAnalysis/_components/ScoreTrend.tsx
@@ -8,15 +8,19 @@ export default function ScoreTrend() {
   const scoreTrendData = getScoreTrendData(4);
   const numData = scoreTrendData.length;
 
-  const thisYear = +scoreTrendData[numData - 1].label;
-  const scoreDiff =
-    scoreTrendData[numData - 1].value - scoreTrendData[numData - 2].value;
+  const thisYear = Number(scoreTrendData[numData - 1].label);
+  const scoreDiff = useMemo(() => {
+    if (numData < 2) return 0;
+    return (
+      scoreTrendData[numData - 1].value - scoreTrendData[numData - 2].value
+    );
+  }, [numData, scoreTrendData]);
 
   const object = useMemo(() => {
     if (numData < 2) return `${scoreTrendData[0].value}점 입니다.`;
     if (scoreDiff === 0) return '지난해와 같아요.';
 
-    const nearestYear = +scoreTrendData[numData - 2].label;
+    const nearestYear = Number(scoreTrendData[numData - 2].label);
     if (thisYear - nearestYear > 1) return `${nearestYear}년보다`;
     return '지난해보다';
   }, [thisYear, numData, scoreDiff, scoreTrendData]);
@@ -35,7 +39,7 @@ export default function ScoreTrend() {
   return (
     <>
       <ResultBox
-        subject={`${numData < 2 ? `${thisYear}년 ` : ''}건강 점수는`}
+        subject={numData < 2 ? `${thisYear}년 ` : '총점이'}
         object={object}
         worseOrBetter={worseOrBetter}
         commentOnScore={commentOnScore}
@@ -46,7 +50,7 @@ export default function ScoreTrend() {
         highlightOn={scoreTrendData.length - 1}
         highlightPoint
         padding={25}
-        barScale={1.1}
+        barScale={1}
       />
     </>
   );

--- a/src/components/common/ScoreChart/index.tsx
+++ b/src/components/common/ScoreChart/index.tsx
@@ -1,8 +1,9 @@
+import { useMemo } from 'react';
 import cx from 'classnames';
 import { useRectBound } from './_hooks';
 import styles from './scoreChart.module.scss';
 
-const DEFAULT_BAR_SCALE = 0.4;
+const BAR_SCLAE_FACTOR = 0.4;
 const LABEL_TOP = 20;
 const CHART_HEIGHT_RATIO = 6 / 7;
 
@@ -31,9 +32,17 @@ export default function ScoreChart({
 }: ScoreChartProps) {
   const { boundRef, boundHeight, boundWidth } = useRectBound<HTMLDivElement>();
 
-  const barWidth = ((boundWidth * DEFAULT_BAR_SCALE) / data.length) * barScale;
-  const barSpacing =
-    (boundWidth - padding * 2 - barWidth * data.length) / (data.length - 1);
+  const barWidth =
+    ((boundWidth * BAR_SCLAE_FACTOR) /
+      (data.length > 1 ? 1 : 2) /
+      data.length) *
+    barScale;
+  const barSpacing = useMemo(() => {
+    if (data.length < 2) return 0;
+    return (
+      (boundWidth - padding * 2 - barWidth * data.length) / (data.length - 1)
+    );
+  }, [data.length, boundWidth, padding, barWidth]);
 
   const values = data.map((datum) => (datum.value > 0 ? datum.value : 0));
   const maxValue = Math.max(...values);
@@ -122,6 +131,7 @@ export default function ScoreChart({
           margin: `0 ${padding}px`,
           width: boundWidth - 2 * padding - barWidth,
           height: boundHeight - LABEL_TOP,
+          justifyContent: data.length < 2 ? 'center' : 'space-between',
         }}
       >
         {bars}
@@ -131,6 +141,7 @@ export default function ScoreChart({
         style={{
           borderTop: `1px solid ${axisColor}`,
           padding: `0 ${padding}px`,
+          justifyContent: data.length < 2 ? 'center' : 'space-between',
         }}
       >
         {tickLabels}

--- a/src/components/common/ScoreChart/index.tsx
+++ b/src/components/common/ScoreChart/index.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import cx from 'classnames';
-import { useMemo } from 'react';
 import { useRectBound } from './_hooks';
 import styles from './scoreChart.module.scss';
 


### PR DESCRIPTION
#12 에서 일부 추가 수정했습니다.

* 과제 지시사항을 보면 '직전 4개년'의 데이터를 가져오라고 되어 있습니다. 따라서 최근 4개 데이터에 속하더라도, 4년 이내 범위에 있는지 검사하는 과정이 필요합니다. 2018년 데이터가 없는 현재 데이터에서는 막대가 3개만 나오는 것이 맞습니다.
* 차트의 막대 너비를 barScale prop으로 지정하고 있기 때문에 막대가 하나일 때 너비를 상수로 지정하면 차트를 사용하는 페이지에서 지정한 설정이 적용되지 않는 문제가 있습니다.  대신 데이터 개수가 1이면 너비를 2로 나누도록 했습니다.
* '건강 점수는'이라는 말을 빼고 '총점이'라는 말을 넣었습니다. (데이터 개수가 2 이상인 경우)
* 데이터가 하나일 때 가운데 정렬되도록 수정했습니다.