### PR TITLE
ScoreChart 애니메이션 추가

### DIFF
--- a/src/components/ScoreAnalysis/_components/AverageAnalysis.tsx
+++ b/src/components/ScoreAnalysis/_components/AverageAnalysis.tsx
@@ -1,8 +1,13 @@
+import type { RefObject } from 'react';
 import { HealthInfo } from 'data';
 import BinaryChart from './_shared/BinaryChart';
 import { ResultBox } from './_shared/ResultBox';
 
-function AverageAnalysis(): JSX.Element {
+interface AverageAnlysisProps {
+  appRef: RefObject<HTMLDivElement>;
+}
+
+function AverageAnalysis({ appRef }: AverageAnlysisProps): JSX.Element {
   const percentData = 100 - Number(HealthInfo.wxcResultMap.hscorePercent);
   const commentPercentData = `${
     percentData > 50 ? '하위' : '상위'
@@ -55,7 +60,7 @@ function AverageAnalysis(): JSX.Element {
         worseOrBetter={hScoreGapClassName}
         commentOnRank={commentPercentData}
       />
-      <BinaryChart data={dataList} />
+      <BinaryChart data={dataList} appRef={appRef} />
     </>
   );
 }

--- a/src/components/ScoreAnalysis/_components/PredictAnalysis.tsx
+++ b/src/components/ScoreAnalysis/_components/PredictAnalysis.tsx
@@ -1,8 +1,13 @@
+import type { RefObject } from 'react';
 import { HealthInfo } from 'data';
 import BinaryChart from './_shared/BinaryChart';
 import { ResultBox } from './_shared/ResultBox';
 
-function PredictAnalysis(): JSX.Element {
+interface PredictAnalysisProps {
+  appRef: RefObject<HTMLDivElement>;
+}
+
+function PredictAnalysis({ appRef }: PredictAnalysisProps): JSX.Element {
   const userHscore = Number(HealthInfo.wxcResultMap.wHscore);
   const predictHscore = HealthInfo.wxcResultMap.wHscoreDy
     .substring(1, HealthInfo.wxcResultMap.wHscoreDy.length - 1)
@@ -42,7 +47,7 @@ function PredictAnalysis(): JSX.Element {
         commentOnScore={hScoreGapComment}
         worseOrBetter={hScoreGapClassName}
       />
-      <BinaryChart data={dataList} />
+      <BinaryChart data={dataList} appRef={appRef} />
     </>
   );
 }

--- a/src/components/ScoreAnalysis/_components/PredictExpense.tsx
+++ b/src/components/ScoreAnalysis/_components/PredictExpense.tsx
@@ -1,8 +1,13 @@
+import type { RefObject } from 'react';
 import { HealthInfo } from 'data';
 import BinaryChart from './_shared/BinaryChart';
 import { ResultBox } from './_shared/ResultBox';
 
-function PredictExpense(): JSX.Element {
+interface PredictExpenseProps {
+  appRef: RefObject<HTMLDivElement>;
+}
+
+function PredictExpense({ appRef }: PredictExpenseProps): JSX.Element {
   const userMedi = Number(HealthInfo.wxcResultMap.medi);
   const predictMedi = HealthInfo.wxcResultMap.mediDy
     .substring(1, HealthInfo.wxcResultMap.mediDy.length - 1)
@@ -42,7 +47,7 @@ function PredictExpense(): JSX.Element {
         commentOnScore={hScoreGapComment}
         worseOrBetter={hScoreGapClassName}
       />
-      <BinaryChart data={dataList} />
+      <BinaryChart data={dataList} appRef={appRef} />
     </>
   );
 }

--- a/src/components/ScoreAnalysis/_components/ScoreTrend.tsx
+++ b/src/components/ScoreAnalysis/_components/ScoreTrend.tsx
@@ -1,10 +1,15 @@
 import { useMemo } from 'react';
+import type { RefObject } from 'react';
 import ScoreChart from 'components/common/ScoreChart';
 import { getScoreTrendData } from 'components/ScoreAnalysis/_utils';
 import { ResultBox } from './_shared/ResultBox';
 import styles from '../scoreAnalysis.module.scss';
 
-export default function ScoreTrend() {
+interface ScoreTrendProps {
+  appRef: RefObject<HTMLDivElement>;
+}
+
+export default function ScoreTrend({ appRef }: ScoreTrendProps) {
   const scoreTrendData = getScoreTrendData(4);
   const numData = scoreTrendData.length;
   const thisYear = new Date().getFullYear();
@@ -51,6 +56,7 @@ export default function ScoreTrend() {
         highlightPoint
         padding={25}
         barScale={1}
+        appRef={appRef}
       />
     </>
   );

--- a/src/components/ScoreAnalysis/_components/_shared/BinaryChart/index.tsx
+++ b/src/components/ScoreAnalysis/_components/_shared/BinaryChart/index.tsx
@@ -1,11 +1,13 @@
+import type { RefObject } from 'react';
 import ScoreChart from 'components/common/ScoreChart';
 import styles from './binaryChart.module.scss';
 
 interface CompareChartProps {
   data: ChartData[];
+  appRef: RefObject<HTMLElement>;
 }
 
-export default function BinaryChart({ data }: CompareChartProps) {
+export default function BinaryChart({ data, appRef }: CompareChartProps) {
   return (
     <ScoreChart
       className={styles.chart}
@@ -15,6 +17,7 @@ export default function BinaryChart({ data }: CompareChartProps) {
       highlightPoint
       barScale={0.9}
       padding={50}
+      appRef={appRef}
     />
   );
 }

--- a/src/components/ScoreAnalysis/index.tsx
+++ b/src/components/ScoreAnalysis/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import type { RefObject } from 'react';
 import { HealthInfo } from 'data';
 import Detail from 'components/Detail';
 import {
@@ -9,7 +10,11 @@ import {
 } from './_components';
 import styles from './scoreAnalysis.module.scss';
 
-function ScoreAnalyze() {
+interface ScoreAnalyzeProps {
+  appRef: RefObject<HTMLDivElement>;
+}
+
+function ScoreAnalyze({ appRef }: ScoreAnalyzeProps) {
   const [detail, setDetail] = useState(false);
   const handleClickButton = () => {
     setDetail(true);
@@ -39,11 +44,11 @@ function ScoreAnalyze() {
           결과 자세히 보기
         </button>
       </div>
-      <ScoreTrend />
-      <AverageAnalysis />
+      <ScoreTrend appRef={appRef} />
+      <AverageAnalysis appRef={appRef} />
       <h2 className={styles.resultTitle}>나의 10년 후 건강 예측</h2>
-      <PredictAnalysis />
-      <PredictExpense />
+      <PredictAnalysis appRef={appRef} />
+      <PredictExpense appRef={appRef} />
     </section>
   );
 }

--- a/src/components/common/ScoreChart/_hooks.ts
+++ b/src/components/common/ScoreChart/_hooks.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, RefObject } from 'react';
 
 export const useRectBound = <T extends HTMLElement>() => {
   const boundRef = useRef<T>(null);
@@ -12,4 +12,45 @@ export const useRectBound = <T extends HTMLElement>() => {
   }, [boundRef, setBoundHeight, setBoundWidth]);
 
   return { boundRef, boundHeight, boundWidth };
+};
+
+export const useIntersectionObserver = <
+  T extends HTMLElement,
+  S extends HTMLElement
+>(
+  containerRef: RefObject<T> | undefined,
+  boundRef: RefObject<S>
+) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const handleObserve = (
+    [entry]: IntersectionObserverEntry[],
+    observer: IntersectionObserver
+  ) => {
+    if (entry.isIntersecting) {
+      setIsVisible(true);
+      observer.unobserve(entry.target);
+    }
+  };
+
+  useEffect(() => {
+    let observer: IntersectionObserver;
+
+    if (containerRef?.current && boundRef.current) {
+      const options = {
+        root: containerRef.current,
+        threshold: 0.75,
+      };
+      observer = new IntersectionObserver(handleObserve, options);
+      observer.observe(boundRef.current);
+    }
+
+    return () => {
+      if (observer) {
+        observer.disconnect();
+      }
+    };
+  }, [containerRef, boundRef]);
+
+  return { isVisible };
 };

--- a/src/components/common/ScoreChart/_utils.ts
+++ b/src/components/common/ScoreChart/_utils.ts
@@ -1,0 +1,35 @@
+const BAR_SCLAE_FACTOR = 0.4;
+
+interface BarDimensionOptions {
+  boundWidth: number;
+  boundHeight: number;
+  barScale: number;
+  padding: number;
+}
+
+export const cutoutBar = (
+  data: ChartData[],
+  { boundWidth, boundHeight, barScale, padding }: BarDimensionOptions
+) => {
+  const barWidth =
+    ((boundWidth * BAR_SCLAE_FACTOR) /
+      (data.length > 1 ? 1 : 2) /
+      data.length) *
+    barScale;
+
+  const barSpacing =
+    data.length >= 2
+      ? (boundWidth - padding * 2 - barWidth * data.length) / (data.length - 1)
+      : 0;
+
+  const values = data.map((datum) => (datum.value > 0 ? datum.value : 0));
+  const maxValue = Math.max(...values);
+  const divider = maxValue > 0 ? maxValue : 1;
+
+  const barHeights = values.map(
+    (value) => Math.max(((boundHeight - 20) * value) / divider),
+    20
+  );
+
+  return { barWidth, barSpacing, barHeights };
+};

--- a/src/components/common/ScoreChart/index.tsx
+++ b/src/components/common/ScoreChart/index.tsx
@@ -1,10 +1,9 @@
-import { useMemo } from 'react';
 import type { RefObject } from 'react';
 import cx from 'classnames';
 import { useIntersectionObserver, useRectBound } from './_hooks';
+import { cutoutBar } from './_utils';
 import styles from './scoreChart.module.scss';
 
-const BAR_SCLAE_FACTOR = 0.4;
 const LABEL_TOP = 20;
 const CHART_HEIGHT_RATIO = 6 / 7;
 
@@ -36,27 +35,12 @@ export default function ScoreChart({
   const { boundRef, boundHeight, boundWidth } = useRectBound<HTMLDivElement>();
   const { isVisible } = useIntersectionObserver(appRef, boundRef);
 
-  const barWidth =
-    ((boundWidth * BAR_SCLAE_FACTOR) /
-      (data.length > 1 ? 1 : 2) /
-      data.length) *
-    barScale;
-
-  const barSpacing = useMemo(() => {
-    if (data.length < 2) return 0;
-    return (
-      (boundWidth - padding * 2 - barWidth * data.length) / (data.length - 1)
-    );
-  }, [data.length, boundWidth, padding, barWidth]);
-
-  const values = data.map((datum) => (datum.value > 0 ? datum.value : 0));
-  const maxValue = Math.max(...values);
-  const divider = maxValue > 0 ? maxValue : 1;
-
-  const barHeights = values.map(
-    (value) => Math.max(((boundHeight - 20) * value) / divider),
-    20
-  );
+  const { barWidth, barSpacing, barHeights } = cutoutBar(data, {
+    boundWidth,
+    boundHeight,
+    barScale,
+    padding,
+  });
 
   const bars = barHeights.map((height, idx) => {
     const key = `chart-${data[idx].label}-${idx}`;

--- a/src/components/common/ScoreChart/index.tsx
+++ b/src/components/common/ScoreChart/index.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
+import type { RefObject } from 'react';
 import cx from 'classnames';
-import { useRectBound } from './_hooks';
+import { useIntersectionObserver, useRectBound } from './_hooks';
 import styles from './scoreChart.module.scss';
 
 const BAR_SCLAE_FACTOR = 0.4;
@@ -17,6 +18,7 @@ interface ScoreChartProps {
   pointStyle?: 'circle' | 'square';
   padding?: number;
   className?: string;
+  appRef?: RefObject<HTMLElement>;
 }
 
 export default function ScoreChart({
@@ -25,12 +27,14 @@ export default function ScoreChart({
   secondaryHighlightOn,
   highlightPoint = false,
   barScale = 1,
-  axisColor = '#000',
+  axisColor = '#111827',
   pointStyle = 'circle',
   padding = 0,
   className,
+  appRef,
 }: ScoreChartProps) {
   const { boundRef, boundHeight, boundWidth } = useRectBound<HTMLDivElement>();
+  const { isVisible } = useIntersectionObserver(appRef, boundRef);
 
   const barWidth =
     ((boundWidth * BAR_SCLAE_FACTOR) /
@@ -126,30 +130,34 @@ export default function ScoreChart({
 
   return (
     <div className={cx(styles.wrapper, className)} ref={boundRef}>
-      <div
-        className={styles.barsWrapper}
-        style={{
-          margin: `0 ${padding}px`,
-          width: boundWidth - 2 * padding - barWidth,
-          height: boundHeight - LABEL_TOP,
-          justifyContent: data.length < 2 ? 'center' : 'space-between',
-        }}
-      >
-        {bars}
-      </div>
-      <div
-        className={cx(styles.tickLabels)}
-        style={{
-          borderTop: `1px solid ${axisColor}`,
-          padding: `0 ${padding}px`,
-          justifyContent: data.length < 2 ? 'center' : 'space-between',
-        }}
-      >
-        {tickLabels}
-      </div>
-      <svg className={styles.lines} width={boundWidth}>
-        {lines}
-      </svg>
+      {isVisible && (
+        <>
+          <div
+            className={styles.barsWrapper}
+            style={{
+              margin: `0 ${padding}px`,
+              width: boundWidth - 2 * padding - barWidth,
+              height: boundHeight - LABEL_TOP,
+              justifyContent: data.length < 2 ? 'center' : 'space-between',
+            }}
+          >
+            {bars}
+          </div>
+          <div
+            className={cx(styles.tickLabels)}
+            style={{
+              borderTop: `1px solid ${axisColor}`,
+              padding: `0 ${padding}px`,
+              justifyContent: data.length < 2 ? 'center' : 'space-between',
+            }}
+          >
+            {tickLabels}
+          </div>
+          <svg className={styles.lines} width={boundWidth}>
+            {lines}
+          </svg>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/common/ScoreChart/scoreChart.module.scss
+++ b/src/components/common/ScoreChart/scoreChart.module.scss
@@ -24,7 +24,7 @@
       height: max(calc(100% - 20px), 0px);
       background-color: colors.$gray-200;
       animation: 1s grow;
-      animation-fill-mode: 'both';
+      animation-fill-mode: both;
       animation-delay: 50ms;
 
       .label {
@@ -34,7 +34,7 @@
         left: 0;
         z-index: 100;
         height: 20px;
-        color: colors.$gray-300;
+        color: colors.$gray-500;
         text-align: center;
       }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import MyHealth from 'components/MyHealth';
 import StatusBar from 'components/StatusBar';
 import HealthCards from 'components/HealthCards';
@@ -6,12 +7,14 @@ import styles from './app.module.scss';
 import ScoreAnalyze from '../components/ScoreAnalysis';
 
 function App() {
+  const appRef = useRef<HTMLDivElement>(null);
+
   return (
     <div className={styles.appWrapper}>
-      <div id="app" className={styles.app}>
+      <div id="app" className={styles.app} ref={appRef}>
         <StatusBar />
         <MyHealth />
-        <ScoreAnalyze />
+        <ScoreAnalyze appRef={appRef} />
         <HealthCards />
       </div>
     </div>


### PR DESCRIPTION
* 스크롤에 따라 차트가 나타나도록 해서 애니메이션이 보이게 했습니다. (IntersectionObersever로 구현)
* `ScoreChart` 컴포넌트 코드 길이가 길어서 리팩토링 했습니다.
* 차트 위 숫자 둥 강조되지 않은 숫자 색이 흐리멍텅한 회색의 표본인 것 같아서 `gray-500`으로 바꿨습니다.